### PR TITLE
fix: Prevent Render server restarts from memory exhaustion and unhandled errors

### DIFF
--- a/mudlib/config/game.json
+++ b/mudlib/config/game.json
@@ -1,7 +1,7 @@
 {
   "name": "MudForge",
   "tagline": "Your Adventure Awaits",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A Modern MUD Experience",
   "establishedYear": 2026,
   "website": "https://www.mudforge.org"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mudforge-driver",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A modern MUD (Multi-User Dungeon) driver inspired by LDMud, built with Node.js and TypeScript. Features sandboxed script execution, hot-reload, and WebSocket-based web client.",
   "type": "module",
   "main": "dist/driver/index.js",

--- a/src/driver/config.ts
+++ b/src/driver/config.ts
@@ -19,6 +19,7 @@ export interface DriverConfig {
 
   // Isolation/Sandbox
   isolateMemoryMb: number;
+  maxIsolates: number;
   scriptTimeoutMs: number;
 
   // Scheduler
@@ -125,8 +126,9 @@ export function loadConfig(): DriverConfig {
     // HTTP request logging (default off to reduce noise)
     logHttpRequests: parseBoolean(process.env['LOG_HTTP_REQUESTS'], false),
 
-    // Isolation/Sandbox
-    isolateMemoryMb: parseNumber(process.env['ISOLATE_MEMORY_MB'], 128),
+    // Isolation/Sandbox (lower defaults for memory-constrained environments like Render free tier)
+    isolateMemoryMb: parseNumber(process.env['ISOLATE_MEMORY_MB'], 64),
+    maxIsolates: parseNumber(process.env['MAX_ISOLATES'], 2),
     scriptTimeoutMs: parseNumber(process.env['SCRIPT_TIMEOUT_MS'], 5000),
 
     // Scheduler

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -285,6 +285,7 @@ export class Driver {
       // Initialize isolate pool (for future sandbox use)
       getIsolatePool({
         memoryLimitMb: this.config.isolateMemoryMb,
+        maxIsolates: this.config.maxIsolates,
       });
 
       // Load Master object

--- a/tests/driver/config.test.ts
+++ b/tests/driver/config.test.ts
@@ -27,7 +27,8 @@ describe('loadConfig', () => {
     expect(config.masterObject).toBe('/master');
     expect(config.logLevel).toBe('info');
     expect(config.logPretty).toBe(true);
-    expect(config.isolateMemoryMb).toBe(128);
+    expect(config.isolateMemoryMb).toBe(64);
+    expect(config.maxIsolates).toBe(2);
     expect(config.scriptTimeoutMs).toBe(5000);
     expect(config.heartbeatIntervalMs).toBe(2000);
     expect(config.autoSaveIntervalMs).toBe(300000);
@@ -90,7 +91,7 @@ describe('loadConfig', () => {
     const config = loadConfig();
 
     expect(config.port).toBe(3000);
-    expect(config.isolateMemoryMb).toBe(128);
+    expect(config.isolateMemoryMb).toBe(64);
   });
 });
 
@@ -102,7 +103,8 @@ describe('validateConfig', () => {
     masterObject: '/master',
     logLevel: 'info',
     logPretty: true,
-    isolateMemoryMb: 128,
+    isolateMemoryMb: 64,
+    maxIsolates: 2,
     scriptTimeoutMs: 5000,
     heartbeatIntervalMs: 2000,
     autoSaveIntervalMs: 300000,


### PR DESCRIPTION
## Summary
- Add global error handlers (`uncaughtException`/`unhandledRejection`) to prevent crashes from unhandled errors
- Add 15-second timeout to graceful shutdown to prevent hanging on SIGTERM
- Reduce default isolate memory from 128MB → 64MB and max isolates from 4 → 2 (configurable via `ISOLATE_MEMORY_MB` and `MAX_ISOLATES` env vars)
- Add 25-second timeout to all external API calls (Claude, Gemini, GitHub, Giphy) to prevent blocking event loop and failing health checks

## Test plan
- [x] TypeScript compiles without errors
- [x] All tests pass (except pre-existing Windows path traversal test on macOS)
- [ ] Deploy to Render and monitor for restarts during combat
- [ ] Verify AI features still work with new timeouts
- [ ] Check memory usage stays under 512MB on free tier

🤖 Generated with [Claude Code](https://claude.ai/code)