### PR TITLE
v1.7.5: Fix WebSocket idle disconnects

### DIFF
--- a/mudlib/config/game.json
+++ b/mudlib/config/game.json
@@ -1,7 +1,7 @@
 {
   "name": "MudForge",
   "tagline": "Your Adventure Awaits",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "A Modern MUD Experience",
   "establishedYear": 2026,
   "website": "https://www.mudforge.org"

--- a/src/client/websocket-client.ts
+++ b/src/client/websocket-client.ts
@@ -571,6 +571,9 @@ export class WebSocketClient {
           } catch (error) {
             console.error('Failed to parse SESSION message:', error);
           }
+        } else if (line.startsWith('\x00[KEEPALIVE]')) {
+          // Server keep-alive message - silently ignore
+          // These are sent to create data frames that keep load balancers happy
         } else {
           this.emit('message', line);
         }


### PR DESCRIPTION
## Summary

Fix for long-lived WebSocket connections being killed by Render's load balancer after ~5 hours of idle time.

## Problem

Even though the server was sending WebSocket ping frames every 45 seconds (and receiving pongs), connections were being terminated with code 1006 (abnormal closure). The TCP connection was being killed at the network layer by the load balancer, which doesn't recognize WebSocket ping/pong as "activity."

**Evidence from logs:**
```
[WS-CLOSE] Connection conn-7 (Acer) closed - code: 1006, reason: ""
[WS-CLOSE] Connection was open for 18502885ms, missed pongs: 0
```

## Solution

Send actual WebSocket **data frames** in addition to ping frames. Load balancers recognize data frames as real traffic.

- Add `sendKeepAlive()` method that sends `\x00[KEEPALIVE]` data frames
- Server heartbeat now sends both ping AND keep-alive every 45 seconds
- Client silently ignores keep-alive messages
- Added connection lifecycle logging for debugging

## Test plan

- [ ] Deploy and leave connection idle overnight
- [ ] Verify no 1006 disconnects in logs
- [ ] Check for `[WS-KEEPALIVE]` or similar in network traffic

🤖 Generated with [Claude Code](https://claude.ai/code)