### PR TITLE
feat: Add clock display to client header with server time sync

### DIFF
--- a/mudlib/config/game.json
+++ b/mudlib/config/game.json
@@ -1,7 +1,7 @@
 {
   "name": "MudForge",
   "tagline": "Your Adventure Awaits",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "A Modern MUD Experience",
   "establishedYear": 2026,
   "website": "https://www.mudforge.org"

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -16,6 +16,7 @@ import {
   CombatMessage,
   SoundMessage,
   GiphyMessage,
+  TimeMessage,
   ReconnectProgress,
   ConnectionState,
 } from './websocket-client.js';
@@ -28,6 +29,7 @@ import { QuestPanel } from './quest-panel.js';
 import { CommPanel } from './comm-panel.js';
 import { CombatPanel } from './combat-panel.js';
 import { GiphyPanel } from './giphy-panel.js';
+import { ClockPanel } from './clock-panel.js';
 import { SoundManager } from './sound-manager.js';
 import { SoundPanel } from './sound-panel.js';
 import { GUIModal } from './gui/gui-modal.js';
@@ -50,6 +52,7 @@ class MudClient {
   private commPanel: CommPanel;
   private combatPanel: CombatPanel;
   private giphyPanel: GiphyPanel;
+  private clockPanel: ClockPanel;
   private soundManager: SoundManager;
   private soundPanel: SoundPanel;
   private guiModal: GUIModal;
@@ -118,6 +121,7 @@ class MudClient {
     });
     this.combatPanel = new CombatPanel('combat-container');
     this.giphyPanel = new GiphyPanel('giphy-container');
+    this.clockPanel = new ClockPanel('clock-container');
     this.soundManager = new SoundManager();
     this.soundPanel = new SoundPanel('sound-container', this.soundManager);
     this.guiModal = new GUIModal((message: GUIClientMessage) => {
@@ -263,6 +267,11 @@ class MudClient {
     // Giphy panel events
     this.wsClient.on('giphy-message', (message: GiphyMessage) => {
       this.giphyPanel.handleMessage(message);
+    });
+
+    // Time/clock events
+    this.wsClient.on('time-message', (message: TimeMessage) => {
+      this.clockPanel.handleMessage(message);
     });
 
     // Completion events

--- a/src/client/clock-panel.ts
+++ b/src/client/clock-panel.ts
@@ -1,0 +1,164 @@
+/**
+ * ClockPanel - Displays server time in the header with fantasy time periods.
+ *
+ * Time periods match the in-game `time` command:
+ * - midnight (0)
+ * - dead of night (1-4)
+ * - dawn (5-6)
+ * - morning (7-11)
+ * - midday (12)
+ * - afternoon (13-16)
+ * - dusk (17-18)
+ * - evening (19-21)
+ * - night (22-23)
+ */
+
+import type { TimeMessage } from './websocket-client.js';
+
+interface TimePeriod {
+  name: string;
+  color: 'blue' | 'yellow' | 'orange' | 'magenta';
+}
+
+/**
+ * Get time period info based on hour (matches _time.ts logic).
+ */
+function getTimePeriod(hour: number): TimePeriod {
+  if (hour === 0) {
+    return { name: 'Midnight', color: 'blue' };
+  } else if (hour >= 1 && hour < 5) {
+    return { name: 'Night', color: 'blue' };
+  } else if (hour >= 5 && hour < 7) {
+    return { name: 'Dawn', color: 'yellow' };
+  } else if (hour >= 7 && hour < 12) {
+    return { name: 'Morning', color: 'yellow' };
+  } else if (hour >= 12 && hour < 13) {
+    return { name: 'Midday', color: 'yellow' };
+  } else if (hour >= 13 && hour < 17) {
+    return { name: 'Afternoon', color: 'yellow' };
+  } else if (hour >= 17 && hour < 19) {
+    return { name: 'Dusk', color: 'orange' };
+  } else if (hour >= 19 && hour < 22) {
+    return { name: 'Evening', color: 'magenta' };
+  } else {
+    return { name: 'Night', color: 'blue' };
+  }
+}
+
+/**
+ * Format time to 12-hour format with AM/PM.
+ */
+function formatTime12Hour(date: Date): string {
+  const hour = date.getHours();
+  const minute = date.getMinutes();
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const displayHour = hour % 12 || 12;
+  const displayMinute = minute.toString().padStart(2, '0');
+  return `${displayHour}:${displayMinute} ${period}`;
+}
+
+/**
+ * ClockPanel displays server time with fantasy theming.
+ */
+export class ClockPanel {
+  private container: HTMLElement;
+  private periodElement: HTMLElement;
+  private timeElement: HTMLElement;
+  private updateInterval: number | null = null;
+
+  // Server time sync state
+  private serverTimestamp: number = 0;
+  private localSyncTime: number = 0;
+  private timezoneAbbreviation: string = '';
+
+  constructor(containerId: string) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+      throw new Error(`Clock container #${containerId} not found`);
+    }
+    this.container = container;
+
+    // Create clock elements
+    this.periodElement = document.createElement('span');
+    this.periodElement.className = 'clock-period';
+
+    this.timeElement = document.createElement('span');
+    this.timeElement.className = 'clock-time';
+
+    this.container.appendChild(this.periodElement);
+    this.container.appendChild(this.timeElement);
+
+    // Start the local update loop
+    this.startUpdateLoop();
+  }
+
+  /**
+   * Handle a time message from the server.
+   */
+  handleMessage(message: TimeMessage): void {
+    this.serverTimestamp = message.timestamp;
+    this.localSyncTime = Date.now();
+    this.timezoneAbbreviation = message.timezone.abbreviation;
+
+    // Immediately update display
+    this.updateDisplay();
+  }
+
+  /**
+   * Start the local update loop (every second).
+   */
+  private startUpdateLoop(): void {
+    if (this.updateInterval !== null) {
+      return;
+    }
+
+    this.updateInterval = window.setInterval(() => {
+      this.updateDisplay();
+    }, 1000);
+  }
+
+  /**
+   * Stop the update loop.
+   */
+  stop(): void {
+    if (this.updateInterval !== null) {
+      window.clearInterval(this.updateInterval);
+      this.updateInterval = null;
+    }
+  }
+
+  /**
+   * Get the current interpolated time based on server sync.
+   */
+  private getCurrentTime(): Date {
+    if (this.serverTimestamp === 0) {
+      // No server time yet, use local time
+      return new Date();
+    }
+
+    // Calculate elapsed time since last server sync
+    const elapsedMs = Date.now() - this.localSyncTime;
+    const currentTimestamp = this.serverTimestamp + Math.floor(elapsedMs / 1000);
+
+    return new Date(currentTimestamp * 1000);
+  }
+
+  /**
+   * Update the display with current time.
+   */
+  private updateDisplay(): void {
+    const now = this.getCurrentTime();
+    const period = getTimePeriod(now.getHours());
+    const timeStr = formatTime12Hour(now);
+    const tzStr = this.timezoneAbbreviation || '';
+
+    // Update period display
+    this.periodElement.textContent = period.name;
+    this.periodElement.className = `clock-period clock-period-${period.color}`;
+
+    // Update time display
+    this.timeElement.textContent = tzStr ? `${timeStr} ${tzStr}` : timeStr;
+  }
+}
+
+export default ClockPanel;

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -183,7 +183,10 @@
   <div id="app" class="hidden">
     <header id="header">
       <h1>MudForge</h1>
-      <span id="status" class="disconnected">Disconnected</span>
+      <div id="header-right">
+        <div id="clock-container" aria-label="Server time"></div>
+        <span id="status" class="disconnected">Disconnected</span>
+      </div>
     </header>
 
     <main id="main-content">

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -193,6 +193,52 @@ body {
   50% { opacity: 0.4; }
 }
 
+/* Header right group */
+#header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+/* Clock display */
+#clock-container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: 9999px;
+  background-color: var(--bg-tertiary);
+}
+
+.clock-period {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.clock-period-blue {
+  color: var(--ansi-blue);
+}
+
+.clock-period-yellow {
+  color: var(--ansi-yellow);
+}
+
+.clock-period-orange {
+  color: #f97316;
+}
+
+.clock-period-magenta {
+  color: var(--ansi-magenta);
+}
+
+.clock-time {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
 #terminal {
   height: 100%;
   padding: var(--spacing-lg);

--- a/src/network/server.ts
+++ b/src/network/server.ts
@@ -270,10 +270,11 @@ export class Server extends EventEmitter {
         // Send WebSocket ping frame (application-level heartbeat)
         connection.ping();
 
-        // Also send a data-frame keep-alive message
+        // Also send a time message with server timestamp
         // This creates actual WebSocket data frames that load balancers/proxies
         // recognize as "activity", preventing idle connection timeouts
-        connection.sendKeepAlive();
+        // The client displays this as a clock in the header
+        connection.sendTime();
       }
     }, this.heartbeatIntervalMs);
   }


### PR DESCRIPTION
## Summary
- Replace KEEPALIVE message with TIME message containing server timestamp and timezone
- Add clock panel to client header showing fantasy time period (Morning, Dusk, etc.) with actual time
- Clock updates every second via local interpolation between 45s server syncs

## Test plan
- [ ] Connect to game, verify clock appears in header
- [ ] Clock updates smoothly every second
- [ ] Time period changes at correct boundaries (5am dawn, 7am morning, etc.)
- [ ] Disconnect/reconnect - clock resumes correctly
- [ ] TIME message still creates data frames for load balancer compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)